### PR TITLE
Implementation of the CultureOrDefaultConvert.ConvertBack method

### DIFF
--- a/Gu.Wpf.Localization/LanguageSelector/CultureOrDefaultConverter.cs
+++ b/Gu.Wpf.Localization/LanguageSelector/CultureOrDefaultConverter.cs
@@ -24,9 +24,14 @@ namespace Gu.Wpf.Localization
         }
 
         /// <inheritdoc />
-        object IValueConverter.ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        object IValueConverter.ConvertBack(object value, Type targetType, object parameter, CultureInfo _)
         {
-            throw new NotSupportedException($"{nameof(CultureOrDefaultConverter)} can only be used in OneWay bindings");
+            if (value is CultureInfo culture)
+            {
+                return culture;
+            }
+
+            return Translator.CurrentCulture;
         }
     }
 }


### PR DESCRIPTION
I think that CultureOrDefaultConverter needs to implement ConvertBack method in order to swtich the value of Translator.Culture in ComboBox like "1.1. Basic usage".
If ConvertBack method is not implemented, the TwoWay binding will not work and "1.1. Basic usage" example will not work with runtime errors.
I thought to simply return value parameter, but I felt that the same implementation as Convert is optimal.
This will work "1.1. Basic usage" example.