### PR TITLE
UPDATE README: Modify the description of the change of Culture.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Translate a key in a ResourceManager.
 
 Use global culture & error handling:
 ```c#
-Translator.CurrentCulture = CultureInfo.GetCultureInfo("en"); // no need to set this every time, just for illustration purposes here.
+Translator.Culture = CultureInfo.GetCultureInfo("en"); // no need to set this every time, just for illustration purposes here.
 string inEnglish = Translator.Translate(Properties.Resources.ResourceManager,
                                         nameof(Properties.Resources.SomeResource));
 ```
@@ -237,7 +237,7 @@ string inSwedish = Translator.Translate(Properties.Resources.ResourceManager,
 
 #### 2.1.6.5. Translate with parameter:
 ```c#
-Translator.CurrentCulture = CultureInfo.GetCultureInfo("en");
+Translator.Culture = CultureInfo.GetCultureInfo("en");
 string inSwedish = Translator.Translate(Properties.Resources.ResourceManager,
                                         nameof(Properties.Resources.SomeResource__0__),
                                         foo);


### PR DESCRIPTION
README are very important for users, so I would like to fix incorrect descriptions.

Since Translator.CurrentCulture is private, it can not be assigned, resulting in a compile error.
Change to Translator.Culture which can be assigned.

It is the reflection of the rename (ea01b544cbd61b1368c8e22c0df14696ecb5e7db Translator.CurrentCulture -> Translator.Culture).