### PR TITLE
UPDATE README: Modify the twoway bindings of Culture.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The static properties support binding. Use this XAML for a twoway binding:
 <Window ...
         xmlns:localization="clr-namespace:Gu.Localization;assembly=Gu.Localization">
     ...
-<TextBox Text="{Binding Path=(localization:Translator.CurrentCulture)}" />
+<TextBox Text="{Binding Path=(localization:Translator.Culture)}" />
 ```
 
 # 2. Usage in code.


### PR DESCRIPTION
The twoway bindings of Translator.CurrentCulture is a runtime error.
Change in Culture that can be twoway bindings.

This is also a reflection of the rename (ea01b544cbd61b1368c8e22c0df14696ecb5e7db Translator.CurrentCulture -> Translator.Culture).